### PR TITLE
Update npm and solana versions and install anchor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,19 +22,23 @@ RUN mkdir -p /project
 RUN chown -R 999:999 /project
 RUN chmod -R 777 /project
 
-RUN npm install -g npm@7.16.0
-RUN npm install -g npm@7.16.0
+RUN npm install -g npm@8.13.1
+RUN npm install -g npm@8.13.1
 
 
+# SER newuser
+# WORKDIR /home/newuser
 
-#USER newuser
-#WORKDIR /home/newuser
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
-RUN bash -c "$(curl -sSfL https://release.solana.com/v1.5.7/install)"
+RUN bash -c "$(curl -sSfL https://release.solana.com/v1.10.29/install)"
 RUN . $HOME/.cargo/env
 ENV PATH="/root/.local/share/solana/install/active_release/bin:${PATH}"
 ENV RUST_LOG="solana_runtime::system_instruction_processor=trace,solana_runtime::message_processor=debug,solana_bpf_loader=debug,solana_rbpf=debug"
+
+# install anchor and it's dependencies
+RUN apt-get install pkg-config libudev-dev libssl-dev
+RUN cargo install --git https://github.com/project-serum/anchor anchor-cli --locked
 
 WORKDIR /project
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,11 @@ RUN npm install -g npm@8.13.1
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 RUN bash -c "$(curl -sSfL https://release.solana.com/v1.10.29/install)"
 RUN . $HOME/.cargo/env
-ENV PATH="/root/.local/share/solana/install/active_release/bin:${PATH}"
+ENV PATH="/root/.local/share/solana/install/active_release/bin:/root/.cargo/bin:${PATH}"
 ENV RUST_LOG="solana_runtime::system_instruction_processor=trace,solana_runtime::message_processor=debug,solana_bpf_loader=debug,solana_rbpf=debug"
 
 # install anchor and it's dependencies
-RUN apt-get install pkg-config libudev-dev libssl-dev
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libudev-dev libssl-dev
 RUN cargo install --git https://github.com/project-serum/anchor anchor-cli --locked
 
 WORKDIR /project


### PR DESCRIPTION
I was having problems getting setup with Solana using WSL2 on Windows 11 so I decided to dockerize everything instead.

Found your repo and gave it a go. It worked until I needed to install Anchor and then it was missing a few system dependencies and needed more up to date version of `npm` and `solana`.

I think these changes are more suitable for solana development in 2022 given how big a dependency Anchor has now become.